### PR TITLE
chore: Update sdk dependency to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
       - name: install dependencies
         run: npm install
       - name: npm run build

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "pack": "sdk-commands pack-smart-wearable"
   },
   "devDependencies": {
-    "@dcl/js-runtime": "latest",
     "@dcl/sdk": "latest"
   },
   "engines": {


### PR DESCRIPTION
This PR updates the `@dcl/sdk` package to its latest version.

Also removes the dependency `@dcl/js-runtime` from the package.json because it's a sub-dependency of the package `@dcl/sdk`